### PR TITLE
Handle UTF-8 BOM JSON responses

### DIFF
--- a/educabiz/client.py
+++ b/educabiz/client.py
@@ -21,6 +21,8 @@ class Client(requests.Session):
         if url[0] == '/':
             url = f'{self.URL}{url}'
         r = super().request(method, url, *a, **b)
+        if r.content.startswith(b'\xef\xbb\xbf'):
+            r.encoding = 'utf-8-sig'
         # quick check
         if 'https://mobile.educabiz.com/authenticate' in r.text:
             # sure check

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest import mock
 
+import requests
+
 from educabiz import client
 
 
@@ -17,3 +19,14 @@ class Test(unittest.TestCase):
         c = client.Client('x', 'y')
         with self.assertRaises(client.LoginFailedError):
             c.login()
+
+    @mock.patch('educabiz.client.requests.Session.request')
+    def test_response_json_decodes_utf8_bom(self, request_mock):
+        response = requests.Response()
+        response._content = b'\xef\xbb\xbf{"status": "ok"}'
+        request_mock.return_value = response
+
+        c = client.Client('x', 'y')
+        response = c.get('/test')
+
+        self.assertEqual(response.json(), {'status': 'ok'})


### PR DESCRIPTION
## Summary
- detect UTF-8 BOM-prefixed responses in `Client.request()`
- set response encoding to `utf-8-sig` so regular `response.json()` calls work
- add a regression test covering BOM-prefixed JSON responses

## Tests
- `make test`

## Thanks
@diogonmoura
