### PR TITLE
Document Educabiz school routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ pip install educabiz
 
 ## Usage
 
+Educabiz does not provide a way to choose the school during login, matching the
+behavior of the Educabiz mobile app. The portal redirects to the right school
+based on the unique email/password combination, so when using multiple schools
+with the same email address, use the password associated with the intended
+school. If the same password is currently used for multiple schools, log in to
+the first school that opens and change the password there. The old password will
+then redirect to the other school.
+
 ```python
 from educabiz.client import Client
 


### PR DESCRIPTION
## Summary

- Document that Educabiz does not support choosing a school during login.
- Explain that school routing is based on the email/password combination.
- Add the same-password workaround for users connected to multiple schools.

## Tests

- Not run; documentation-only change.
