### PR TITLE
Fix BOM handling after relogin retry

### DIFF
--- a/educabiz/client.py
+++ b/educabiz/client.py
@@ -21,6 +21,8 @@ class Client(requests.Session):
         if url[0] == '/':
             url = f'{self.URL}{url}'
         r = super().request(method, url, *a, **b)
+        if r.content.startswith(b'\xef\xbb\xbf'):
+            r.encoding = 'utf-8-sig'
         # quick check
         if 'https://mobile.educabiz.com/authenticate' in r.text:
             # sure check

--- a/educabiz/client.py
+++ b/educabiz/client.py
@@ -20,9 +20,7 @@ class Client(requests.Session):
     def request(self, method, url, *a, login_if_required=True, **b):
         if url[0] == '/':
             url = f'{self.URL}{url}'
-        r = super().request(method, url, *a, **b)
-        if r.content.startswith(b'\xef\xbb\xbf'):
-            r.encoding = 'utf-8-sig'
+        r = self._normalize_response(super().request(method, url, *a, **b))
         # quick check
         if 'https://mobile.educabiz.com/authenticate' in r.text:
             # sure check
@@ -33,9 +31,14 @@ class Client(requests.Session):
             if data.get('formAction') == 'https://mobile.educabiz.com/authenticate':
                 if login_if_required and self._relogin:
                     self.login()
-                    return super().request(method, url, *a, **b)
+                    return self._normalize_response(super().request(method, url, *a, **b))
                 else:
                     raise LoginRequiredError()
+        return r
+
+    def _normalize_response(self, r):
+        if r.content.startswith(b'\xef\xbb\xbf'):
+            r.encoding = 'utf-8-sig'
         return r
 
     def login(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -30,3 +30,21 @@ class Test(unittest.TestCase):
         response = c.get('/test')
 
         self.assertEqual(response.json(), {'status': 'ok'})
+
+    @mock.patch('educabiz.client.requests.Session.request')
+    def test_relogin_response_json_decodes_utf8_bom(self, request_mock):
+        login_required_response = requests.Response()
+        login_required_response._content = b'{"formAction": "https://mobile.educabiz.com/authenticate"}'
+        login_required_response.status_code = 200
+        login_response = requests.Response()
+        login_response._content = b'{"status": "ok"}'
+        login_response.status_code = 200
+        retried_response = requests.Response()
+        retried_response._content = b'\xef\xbb\xbf{"status": "ok"}'
+        retried_response.status_code = 200
+        request_mock.side_effect = [login_required_response, login_response, retried_response]
+
+        c = client.Client('x', 'y', login_if_required=True)
+        response = c.get('/test')
+
+        self.assertEqual(response.json(), {'status': 'ok'})

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest import mock
 
+import requests
+
 from educabiz import client
 
 
@@ -17,3 +19,14 @@ class Test(unittest.TestCase):
         c = client.Client('x', 'y')
         with self.assertRaises(client.LoginFailedError):
             c.login()
+
+    @mock.patch('educabiz.client.requests.Session.request')
+    def test_response_json_decodes_utf8_bom(self, request_mock):
+        response = requests.Response()
+        response._content = b'\xef\xbb\xbf{"status": "ok"}'
+        request_mock.return_value = response
+
+        c = client.Client('x', 'y')
+        response = c.get('/test')
+
+        self.assertEqual(response.json(), {'status': 'ok'})


### PR DESCRIPTION
## Summary
- centralize response BOM normalization in Client._normalize_response()
- apply normalization to the automatic re-login retry response
- add a regression test for BOM JSON after re-login

## Tests
- uv run pytest