### PR TITLE
Update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,10 +42,10 @@ jobs:
     needs: test
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
@@ -37,10 +37,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 


### PR DESCRIPTION
## Summary

- Update `actions/checkout` from v4 to v7 in test and publish workflows.
- Update `actions/setup-python` from v5 to v6 in test and publish workflows.
- Addresses the Node.js 20 deprecation warnings shown in:
  - https://github.com/fopina/python-educabiz/actions/runs/28787236954
  - https://github.com/fopina/python-educabiz/actions/runs/28787216634

## Verification

- `make lint-check`
- `make test`
